### PR TITLE
Update TestConfig-smoke.properties

### DIFF
--- a/grantsFunding-web-test/src/test/resources/TestConfig-smoke.properties
+++ b/grantsFunding-web-test/src/test/resources/TestConfig-smoke.properties
@@ -23,7 +23,7 @@ saucelabKey=40ab6858-0ac4-4aab-ac44-bb083a262bec
 #envurl= http://rifs-frontend-play-rifs-stable.test.int.ukrifs.org/
 
 #Dev environment
-envurl=http://rifs-frontend-play-rifs-test-smoke.test.int.ukrifs.org/
+envurl=http://rifs-frontend-play-rifs-dev.test.int.ukrifs.org/
 #Smoke env url: 
 #envurl=http://rifs-frontend-play-rifs-test-smoke.test.int.ukrifs.org/
 #envurl=http://rifs-frontend-play-rifs-dev.test.int.ukrifs.org/


### PR DESCRIPTION
Replacing smoke with dev env for smoke test as smoke env is broken - hacky, but doesn't look like i'll get smoke fixed any time soon.